### PR TITLE
enhancement: Added Resource Group ID to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,7 @@
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | ID of the Resource Group created by the module |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "resource_group_id" {
+  description = "ID of the Resource Group created by the module"
+  value       = azurerm_resource_group.this.id
+}


### PR DESCRIPTION
💡 Summary of the pull request
I have added one extra output - Resource Group ID

🛠️ Implementation Details
Added the ID of the Resource Group deployed by the module to the list of Terraform outputs

📝 Additional Information
Required to support RG-level locks created in consuming deployments.

