### PR TITLE
bug: Fix zones prefix

### DIFF
--- a/modules/vhub/main.tf
+++ b/modules/vhub/main.tf
@@ -40,7 +40,7 @@ resource "azurerm_public_ip_prefix" "this" {
   name                = "${var.firewall_name}-pip-prefix"
   location            = var.location
   resource_group_name = var.resource_group_name
-  zones               = var.zones
+  zones               = var.firewall_zones
 
   prefix_length = var.firewall_public_ip_prefix_length
 

--- a/modules/vhub/main.tf
+++ b/modules/vhub/main.tf
@@ -40,6 +40,7 @@ resource "azurerm_public_ip_prefix" "this" {
   name                = "${var.firewall_name}-pip-prefix"
   location            = var.location
   resource_group_name = var.resource_group_name
+  zones               = var.zones
 
   prefix_length = var.firewall_public_ip_prefix_length
 


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
the prefix didn`t include the zone, so ips where given out in non-zoneredundant.

**:rocket: Motivation**
this solves the problem with the prefix beeing in the zone provided to the module.
