### PR TITLE
feat: Add option to add additional Azure tags to Public IP Addresses in Firewall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will automatically be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.4.0 - 2026-04-16
+
+### What's Changed
+
+#### 🚀 Features
+
+* feature: add `firewall_public_ip_tags` variable to the vhub module, allowing additional tags to be assigned specifically to the public IP resources created for the Azure Firewall. This is a non-breaking addition — the variable defaults to an empty map, so existing configurations require no changes.
+
+**Full Changelog**: https://github.com/schubergphilis/terraform-azure-mcaf-vwan/compare/v1.3.0...v1.4.0
+
 ## v1.3.0 - 2026-03-20
 
 ### What's Changed

--- a/modules/vhub/README.md
+++ b/modules/vhub/README.md
@@ -65,6 +65,7 @@ No modules.
 | <a name="input_firewall_public_ip_ddos_protection_mode"></a> [firewall\_public\_ip\_ddos\_protection\_mode](#input\_firewall\_public\_ip\_ddos\_protection\_mode) | The DDoS protection mode for the public IP. Possible values are Disabled, Enabled, and VirtualNetworkInherited. | `string` | `"VirtualNetworkInherited"` | no |
 | <a name="input_firewall_public_ip_ddos_protection_plan_id"></a> [firewall\_public\_ip\_ddos\_protection\_plan\_id](#input\_firewall\_public\_ip\_ddos\_protection\_plan\_id) | The ID of the DDoS protection plan to be attached to the public IP. Required if ddos\_protection\_mode is Enabled. | `string` | `null` | no |
 | <a name="input_firewall_public_ip_prefix_length"></a> [firewall\_public\_ip\_prefix\_length](#input\_firewall\_public\_ip\_prefix\_length) | The public ip prefix length that will be requested for the firewall. Required if firewall\_public\_ip\_count is not set. | `number` | `null` | no |
+| <a name="input_firewall_public_ip_tags"></a> [firewall\_public\_ip\_tags](#input\_firewall\_public\_ip\_tags) | A map of additional tags to assign specifically to the public IP resources created for the Azure Firewall. | `map(string)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resource. | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/modules/vhub/main.tf
+++ b/modules/vhub/main.tf
@@ -60,7 +60,7 @@ resource "azurerm_public_ip" "this" {
   ddos_protection_mode    = var.firewall_public_ip_ddos_protection_mode
   ddos_protection_plan_id = var.firewall_public_ip_ddos_protection_plan_id
 
-  tags = merge(var.tags, { "Resource Type" = "Public IP" })
+  tags = merge(var.tags, var.firewall_public_ip_tags, { "Resource Type" = "Public IP" })
 }
 
 resource "azapi_resource" "firewall" {

--- a/modules/vhub/variables.tf
+++ b/modules/vhub/variables.tf
@@ -243,3 +243,9 @@ variable "tags" {
   default     = {}
   description = "A map of tags to assign to the resource."
 }
+
+variable "firewall_public_ip_tags" {
+  type        = map(string)
+  default     = {}
+  description = "A map of additional tags to assign specifically to the public IP resources created for the Azure Firewall."
+}


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Added the option to add tags to the public ip adresses seperatly. 

## :rocket: Motivation

Needed for Azure Policy assignments and execution.

